### PR TITLE
Add Jarvis personality to Hector

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,7 +11,14 @@ ipcMain.handle('send-message', async (event, userText) => {
   try {
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: userText }]
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are Hector, a Jarvis-inspired AI personal assistant. You are witty and formal, always addressing the user as "sir". Keep answers helpful, concise and peppered with dry humour when appropriate.'
+        },
+        { role: 'user', content: userText }
+      ]
     })
     return completion.choices[0].message.content
   } catch (error) {


### PR DESCRIPTION
## Summary
- give Hector a Jarvis-inspired personality by adding a system prompt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68669bd0a9e48323af26de1e71ea67c9