### PR TITLE
Add Google Sheets memory logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-openai-api-key
+SPREADSHEET_ID=your-google-sheet-id
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ dist/
 
 # Environment files
 .env
-.env.example
 
 # macOS system files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Personal Assistant
 
-This desktop app uses the OpenAI API. To run it, you need an API key.
+This desktop app uses the OpenAI API and stores chats in a Google Sheet.
+To run it, you need an OpenAI key and Google credentials.
 
 1. Copy `.env.example` to `.env`.
-2. Replace `your-openai-api-key` with your own key in `.env`.
+2. Replace the example values in `.env` with your own keys.
 3. Install dependencies with `npm install`.
 4. Start the app with `npm start`.

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 const { app, BrowserWindow, ipcMain } = require('electron')
 const path = require('path')
 const OpenAI = require('openai')
+const { appendMemory } = require('./memory')
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
@@ -20,7 +21,9 @@ ipcMain.handle('send-message', async (event, userText) => {
         { role: 'user', content: userText }
       ]
     })
-    return completion.choices[0].message.content
+    const hectorReply = completion.choices[0].message.content
+    await appendMemory(new Date().toISOString(), userText, hectorReply)
+    return hectorReply
   } catch (error) {
     console.error('OpenAI API error:', error)
     return 'Sorry, I encountered an error. Please try again.'

--- a/memory.js
+++ b/memory.js
@@ -1,0 +1,37 @@
+const { google } = require('googleapis')
+
+let sheets
+let drive
+
+async function initGoogle() {
+  const auth = new google.auth.GoogleAuth({
+    keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+    scopes: [
+      'https://www.googleapis.com/auth/spreadsheets',
+      'https://www.googleapis.com/auth/drive.file'
+    ]
+  })
+  const authClient = await auth.getClient()
+  sheets = google.sheets({ version: 'v4', auth: authClient })
+  drive = google.drive({ version: 'v3', auth: authClient })
+}
+
+async function appendMemory(time, user, hector) {
+  if (!sheets || !drive) {
+    await initGoogle()
+  }
+  const spreadsheetId = process.env.SPREADSHEET_ID
+  try {
+    await drive.files.get({ fileId: spreadsheetId })
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: 'Sheet1!A:C',
+      valueInputOption: 'USER_ENTERED',
+      requestBody: { values: [[time, user, hector]] }
+    })
+  } catch (error) {
+    console.error('Failed to append memory:', error)
+  }
+}
+
+module.exports = { appendMemory }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "dotenv": "^17.0.1",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "googleapis": "^133.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `memory.js` to write chat logs to a Google Sheet using Google APIs
- call the memory function from the main Electron process
- provide sample environment variables in `.env.example`
- update README with instructions for using Google Sheets
- list `googleapis` dependency
- clean up `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68669d3e6dd08323a651d2685aebd25c