### PR TITLE
Add ElevenLabs TTS playback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ SPREADSHEET_ID=your-spreadsheet-id-here
 GOOGLE_APPLICATION_CREDENTIALS=client_secret.json
 
 # Add any new environment variables here as documentation for the team
+# ElevenLabs text-to-speech API key
+ELEVENLABS_API_KEY=your-elevenlabs-api-key-here

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Personal Assistant
 
 This desktop app uses the OpenAI API and stores chats in a Google Sheet.
-To run it, you need an OpenAI key and Google credentials.
+It can also read replies aloud using the ElevenLabs text-to-speech service.
+To run it, you need an OpenAI key, Google credentials and an ElevenLabs key.
 The app now checks that all required environment variables are set
 and will exit with a helpful message if any are missing.
 
 1. Copy `.env.example` to `.env`.
-2. Replace the example values in `.env` with your own keys.
+2. Replace the example values in `.env` with your own keys, including `ELEVENLABS_API_KEY` if you want voice output.
 3. Install dependencies with `npm install`.
 4. Start the app with `npm start`.

--- a/main.js
+++ b/main.js
@@ -8,7 +8,8 @@ function checkEnv() {
   const required = [
     'OPENAI_API_KEY',
     'SPREADSHEET_ID',
-    'GOOGLE_APPLICATION_CREDENTIALS'
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'ELEVENLABS_API_KEY'
   ]
   const missing = required.filter((key) => !process.env[key])
   if (missing.length) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "dotenv": "^17.0.1",
     "google-spreadsheet": "^4.1.4",
     "googleapis": "^133.0.0",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "axios": "^1.6.1",
+    "howler": "^2.2.3"
   }
 }

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1,4 +1,36 @@
 const { ipcRenderer } = require('electron')
+const axios = require('axios')
+const { Howl } = require('howler')
+
+async function speakText(text) {
+    const apiKey = process.env.ELEVENLABS_API_KEY
+    if (!apiKey) {
+        console.error('ELEVENLABS_API_KEY is not set')
+        return
+    }
+
+    try {
+        const response = await axios.post(
+            'https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM',
+            { text },
+            {
+                headers: {
+                    'xi-api-key': apiKey,
+                    'Content-Type': 'application/json',
+                    Accept: 'audio/mpeg'
+                },
+                responseType: 'arraybuffer'
+            }
+        )
+
+        const blob = new Blob([response.data], { type: 'audio/mpeg' })
+        const url = URL.createObjectURL(blob)
+        const sound = new Howl({ src: [url] })
+        sound.play()
+    } catch (error) {
+        console.error('Failed to get audio from ElevenLabs:', error)
+    }
+}
 
 document.querySelector('.chat-input-bar').addEventListener('submit', async (e) => {
     e.preventDefault()
@@ -24,6 +56,7 @@ document.querySelector('.chat-input-bar').addEventListener('submit', async (e) =
         aiMessage.className = 'message assistant'
         aiMessage.textContent = response
         chatWindow.appendChild(aiMessage)
+        speakText(response)
     } catch (error) {
         console.error('Failed to get AI response:', error)
         const errorMessage = document.createElement('div')


### PR DESCRIPTION
## Summary
- add new ElevenLabs API key to env example and env checks
- update README with ElevenLabs setup info
- add axios and howler dependencies
- create a `speakText` function to request ElevenLabs TTS and play audio
- invoke speech after every AI response

## Testing
- `npm install --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f3396e8083239e45f97ea9aec129