### PR TITLE
Enable Howler via preload script

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,8 +57,9 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
     }
   })
 

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const { Howl } = require('howler');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  Howl,
+  sendMessage: (text) => ipcRenderer.invoke('send-message', text),
+  elevenLabsApiKey: process.env.ELEVENLABS_API_KEY
+});


### PR DESCRIPTION
## Summary
- add `preload.js` exposing Howl and IPC
- load the preload script and enable contextIsolation
- update renderer to use `window.electronAPI`
- switch to fetch for ElevenLabs audio

## Testing
- `node -c main.js`
- `node -c renderer/renderer.js`
- `node -c preload.js`
- `npm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8f80f8083239be118d0826e0fc0