### PR TITLE
Add ElevenLabs voice ID support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ GOOGLE_APPLICATION_CREDENTIALS=client_secret.json
 # Add any new environment variables here as documentation for the team
 # ElevenLabs text-to-speech API key
 ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
+# ElevenLabs voice ID (default is male "George")
+ELEVENLABS_VOICE_ID=JBFqnCBsd6RMkjVDRZzb

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ The app now checks that all required environment variables are set
 and will exit with a helpful message if any are missing.
 
 1. Copy `.env.example` to `.env`.
-2. Replace the example values in `.env` with your own keys, including `ELEVENLABS_API_KEY` if you want voice output.
+2. Replace the example values in `.env` with your own keys. Set `ELEVENLABS_API_KEY` and `ELEVENLABS_VOICE_ID` to enable spoken replies.
 3. Install dependencies with `npm install`.
 4. Start the app with `npm start`.

--- a/preload.js
+++ b/preload.js
@@ -2,5 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   sendMessage: (text) => ipcRenderer.invoke('send-message', text),
-  elevenLabsApiKey: process.env.ELEVENLABS_API_KEY
+  elevenLabsApiKey: process.env.ELEVENLABS_API_KEY,
+  elevenLabsVoiceId: process.env.ELEVENLABS_VOICE_ID
 });

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -8,8 +8,9 @@ async function speakText(text) {
     }
 
     try {
+        const voiceId = window.electronAPI.elevenLabsVoiceId || 'JBFqnCBsd6RMkjVDRZzb'
         const response = await fetch(
-            'https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM',
+            `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
             {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
## Summary
- allow configuring ElevenLabs voice in preload and renderer
- document new ELEVENLABS_VOICE_ID variable
- set default sample voice ID in `.env.example`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869049d42d08323a6ed019b5e43b16b