### PR TITLE
Add streaming for OpenAI and realtime TTS

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -2,6 +2,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   sendMessage: (text) => ipcRenderer.invoke('send-message', text),
+  onStreamToken: (cb) => ipcRenderer.on('stream-token', (event, token) => cb(token)),
+  onStreamError: (cb) => ipcRenderer.on('stream-error', (event, msg) => cb(msg)),
   elevenLabsApiKey: process.env.ELEVENLABS_API_KEY,
   elevenLabsVoiceId: process.env.ELEVENLABS_VOICE_ID
 });

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1,70 +1,90 @@
-const { sendMessage, elevenLabsApiKey } = window.electronAPI
+const {
+    sendMessage,
+    onStreamToken,
+    onStreamError,
+    elevenLabsApiKey,
+    elevenLabsVoiceId
+} = window.electronAPI
 
-async function speakText(text) {
+let audioQueue = Promise.resolve()
+function speakChunk(text) {
     const apiKey = elevenLabsApiKey
     if (!apiKey) {
         console.error('ELEVENLABS_API_KEY is not set')
         return
     }
-
-    try {
-        const voiceId = window.electronAPI.elevenLabsVoiceId || 'JBFqnCBsd6RMkjVDRZzb'
-        const response = await fetch(
-            `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
-            {
-                method: 'POST',
-                headers: {
-                    'xi-api-key': apiKey,
-                    'Content-Type': 'application/json',
-                    Accept: 'audio/mpeg'
-                },
-                body: JSON.stringify({ text })
-            }
-        )
-
-        const arrayBuffer = await response.arrayBuffer()
-        const blob = new Blob([arrayBuffer], { type: 'audio/mpeg' })
-        const url = URL.createObjectURL(blob)
-        const audio = new Audio(url)
-        audio.play()
-    } catch (error) {
-        console.error('Failed to get audio from ElevenLabs:', error)
-    }
+    const voiceId = elevenLabsVoiceId || 'JBFqnCBsd6RMkjVDRZzb'
+    fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`, {
+        method: 'POST',
+        headers: {
+            'xi-api-key': apiKey,
+            'Content-Type': 'application/json',
+            Accept: 'audio/mpeg'
+        },
+        body: JSON.stringify({ text })
+    })
+        .then((res) => res.arrayBuffer())
+        .then((buf) => {
+            const blob = new Blob([buf], { type: 'audio/mpeg' })
+            const url = URL.createObjectURL(blob)
+            const audio = new Audio(url)
+            audioQueue = audioQueue.then(
+                () =>
+                    new Promise((resolve) => {
+                        audio.onended = resolve
+                        audio.play()
+                    })
+            )
+        })
+        .catch((err) => {
+            console.error('Failed to get audio from ElevenLabs:', err)
+        })
 }
+
+const chatWindow = document.querySelector('.chat-window')
+let currentAiMessage = null
+
+onStreamToken((token) => {
+    if (currentAiMessage) {
+        currentAiMessage.textContent += token
+        speakChunk(token)
+        chatWindow.scrollTop = chatWindow.scrollHeight
+    }
+})
+
+onStreamError((msg) => {
+    if (currentAiMessage) {
+        currentAiMessage.classList.add('error')
+        currentAiMessage.textContent = msg
+    }
+})
 
 document.querySelector('.chat-input-bar').addEventListener('submit', async (e) => {
     e.preventDefault()
-    
+
     const input = document.querySelector('.chat-input')
     const userText = input.value.trim()
     if (!userText) return
-    
-    // Clear input
+
     input.value = ''
-    
-    // Add user message
-    const chatWindow = document.querySelector('.chat-window')
+
     const userMessage = document.createElement('div')
     userMessage.className = 'message user'
     userMessage.textContent = userText
     chatWindow.appendChild(userMessage)
-    
-    // Get AI response
+
+    currentAiMessage = document.createElement('div')
+    currentAiMessage.className = 'message assistant'
+    chatWindow.appendChild(currentAiMessage)
+    chatWindow.scrollTop = chatWindow.scrollHeight
+
     try {
-        const response = await sendMessage(userText)
-        const aiMessage = document.createElement('div')
-        aiMessage.className = 'message assistant'
-        aiMessage.textContent = response
-        chatWindow.appendChild(aiMessage)
-        speakText(response)
+        await sendMessage(userText)
     } catch (error) {
         console.error('Failed to get AI response:', error)
-        const errorMessage = document.createElement('div')
-        errorMessage.className = 'message assistant error'
-        errorMessage.textContent = 'Sorry, I encountered an error. Please try again.'
-        chatWindow.appendChild(errorMessage)
+        if (currentAiMessage) {
+            currentAiMessage.classList.add('error')
+            currentAiMessage.textContent = 'Sorry, I encountered an error. Please try again.'
+        }
     }
-    
-    // Scroll to bottom
-    chatWindow.scrollTop = chatWindow.scrollHeight
 })


### PR DESCRIPTION
## Summary
- enable streaming in main process OpenAI call
- expose streaming events in the preload script
- play ElevenLabs audio chunks sequentially as they arrive
- update renderer logic to handle streaming tokens and audio

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686909b563788323abe154675c848a67