### PR TITLE
Implement throttled ElevenLabs TTS requests

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -7,38 +7,90 @@ const {
 } = window.electronAPI
 
 let audioQueue = Promise.resolve()
-function speakChunk(text) {
+
+// queue and throttling state
+let pendingText = ''
+let processing = false
+let lastRequestTime = 0
+const REQUEST_INTERVAL = 1000 // 1 second
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchWithRetry(text) {
     const apiKey = elevenLabsApiKey
     if (!apiKey) {
         console.error('ELEVENLABS_API_KEY is not set')
-        return
+        return null
     }
     const voiceId = elevenLabsVoiceId || 'JBFqnCBsd6RMkjVDRZzb'
-    fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`, {
-        method: 'POST',
-        headers: {
-            'xi-api-key': apiKey,
-            'Content-Type': 'application/json',
-            Accept: 'audio/mpeg'
-        },
-        body: JSON.stringify({ text })
-    })
-        .then((res) => res.arrayBuffer())
-        .then((buf) => {
-            const blob = new Blob([buf], { type: 'audio/mpeg' })
-            const url = URL.createObjectURL(blob)
-            const audio = new Audio(url)
-            audioQueue = audioQueue.then(
-                () =>
-                    new Promise((resolve) => {
-                        audio.onended = resolve
-                        audio.play()
-                    })
-            )
-        })
-        .catch((err) => {
-            console.error('Failed to get audio from ElevenLabs:', err)
-        })
+    let backoff = 1000
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            const res = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`, {
+                method: 'POST',
+                headers: {
+                    'xi-api-key': apiKey,
+                    'Content-Type': 'application/json',
+                    Accept: 'audio/mpeg'
+                },
+                body: JSON.stringify({ text })
+            })
+            if (res.status === 429) {
+                await delay(backoff)
+                backoff *= 2
+                continue
+            }
+            if (!res.ok) {
+                throw new Error(`Status ${res.status}`)
+            }
+            return await res.arrayBuffer()
+        } catch (err) {
+            if (attempt === 4) {
+                throw err
+            }
+            await delay(backoff)
+            backoff *= 2
+        }
+    }
+    return null
+}
+
+async function processQueue() {
+    if (processing || !pendingText) return
+    processing = true
+    const wait = Math.max(REQUEST_INTERVAL - (Date.now() - lastRequestTime), 0)
+    await delay(wait)
+    const text = pendingText
+    pendingText = ''
+    try {
+        const buf = await fetchWithRetry(text)
+        if (!buf) return
+        const blob = new Blob([buf], { type: 'audio/mpeg' })
+        const url = URL.createObjectURL(blob)
+        const audio = new Audio(url)
+        audioQueue = audioQueue.then(
+            () =>
+                new Promise((resolve) => {
+                    audio.onended = resolve
+                    audio.play()
+                })
+        )
+    } catch (err) {
+        console.error('Failed to get audio from ElevenLabs:', err)
+    } finally {
+        lastRequestTime = Date.now()
+        processing = false
+        if (pendingText) {
+            processQueue()
+        }
+    }
+}
+
+function queueToken(token) {
+    pendingText += token
+    processQueue()
 }
 
 const chatWindow = document.querySelector('.chat-window')
@@ -47,7 +99,7 @@ let currentAiMessage = null
 onStreamToken((token) => {
     if (currentAiMessage) {
         currentAiMessage.textContent += token
-        speakChunk(token)
+        queueToken(token)
         chatWindow.scrollTop = chatWindow.scrollHeight
     }
 })


### PR DESCRIPTION
## Summary
- queue OpenAI tokens before sending to ElevenLabs
- limit requests to 1 per second
- add exponential backoff when ElevenLabs returns a 429

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68690dbcb64483238c347106f825ca7a