### PR TITLE
Enable web search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This desktop app uses the OpenAI API and stores chats in a Google Sheet.
 It can also read replies aloud using the ElevenLabs text-to-speech service.
 To run it, you need an OpenAI key, Google credentials and an ElevenLabs key.
 The app now checks that all required environment variables are set
-and will exit with a helpful message if any are missing.
+and will exit with a helpful message if any are missing. The OpenAI
+request configuration now includes a *web search* tool so the model can
+look up information online when needed.
 
 1. Copy `.env.example` to `.env`.
 2. Replace the example values in `.env` with your own keys. Set `ELEVENLABS_API_KEY` and `ELEVENLABS_VOICE_ID` to enable spoken replies.

--- a/main.js
+++ b/main.js
@@ -35,6 +35,10 @@ ipcMain.handle('send-message', async (event, userText) => {
     const completion = await openai.chat.completions.create({
       model: 'gpt-4',
       stream: true,
+      tools: [
+        { type: 'web_search' }
+      ],
+      tool_choice: 'auto',
       messages: [
           {
             role: 'system',


### PR DESCRIPTION
## Summary
- configure OpenAI call with `web_search` tool
- document new capability in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68690fe4667c8323b216b68cc6ccbf8f