### PR TITLE
Fix double encoding in search tool

### DIFF
--- a/utils/searchWeb.js
+++ b/utils/searchWeb.js
@@ -17,7 +17,7 @@ async function searchWeb(query) {
       params: {
         key: GOOGLE_API_KEY,
         cx: GOOGLE_CSE_ID,
-        q: encodeURIComponent(query.trim()),
+        q: query.trim(),
         num: 3
       }
     });


### PR DESCRIPTION
## Summary
- avoid double URL encoding when sending search queries to Google

## Testing
- `node -e "const { searchWeb } = require('./utils/searchWeb'); searchWeb('openai').then(r => console.log('RESULT', r.substring(0,60))).catch(e => console.error('ERR', e));"` *(fails: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_686926d1e8e88323b3202c6fd8bbe585