### PR TITLE
Fix search tool conditions

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,13 +78,16 @@ Remember: you are Hector, not an AI model. Do not mention your internal tools, A
     const needSearch = /search the web|look up|stock price|real-time|current news|price of|value of|latest/i.test(userText);
     let fullReply = '';
 
+    const initialOptions = { model: 'gpt-4', messages };
     if (needSearch) {
-      const firstRes = await openai.chat.completions.create({
-        model: 'gpt-4',
-        messages,
-        tools: [searchWebTool],
-        tool_choice: 'auto'
-      });
+      initialOptions.tools = [searchWebTool];
+      initialOptions.tool_choice = 'auto';
+    } else {
+      initialOptions.stream = true;
+    }
+
+    if (needSearch) {
+      const firstRes = await openai.chat.completions.create(initialOptions);
 
       const assistantMsg = firstRes.choices[0].message;
       messages.push(assistantMsg);
@@ -140,11 +143,7 @@ Remember: you are Hector, not an AI model. Do not mention your internal tools, A
         }
       }
     } else {
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4',
-        stream: true,
-        messages
-      });
+      const completion = await openai.chat.completions.create(initialOptions);
 
       for await (const chunk of completion) {
         const token = chunk.choices[0]?.delta?.content;


### PR DESCRIPTION
## Summary
- avoid passing search_web tool when user doesn't ask for real-time info
- streamline config object for OpenAI requests

## Testing
- `npm run start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_68693154a3ec8323b0222288cc8a1ec3