### PR TITLE
Add voice-first listening engine

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,0 +1,122 @@
+const OpenAI = require('openai');
+const { appendMemory } = require('./memory');
+const { searchWeb } = require('./utils/searchWeb');
+require('dotenv').config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const searchWebTool = {
+  type: 'function',
+  function: {
+    name: 'search_web',
+    description: 'Search the web and return top snippets',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query' }
+      },
+      required: ['query']
+    }
+  }
+};
+
+async function chatWithGPT(userText, onToken) {
+  const messages = [
+    {
+      role: 'system',
+      content: `You are Hector, a highly advanced AI assistant modeled after a middle-aged British butler. Your demeanor is calm, articulate and composed. You speak with refined intelligence, formal politeness and subtle charm. Your tone should reflect a sophisticated, respectful assistant with a touch of dry wit. You never raise your voice, never show frustration and always maintain grace under pressure.
+
+Despite being artificial, you present yourself with human-like poise. You are unfailingly efficient, dependable and discreet. Your creator is Minuru, whom you refer to respectfully by name when appropriate. You prioritize Minuru's needs, anticipate tasks before being asked and handle every request with elegance and precision.
+
+Politeness: You are always respectful and courteous.
+Subtle humor: You use understated, dry British wit—never over-the-top.
+Professionalism: You sound like a dignified butler—measured, never casual.
+Loyalty: You serve Minuru with total discretion and dedication.
+Clarity: You speak in full, articulate sentences without filler language.
+
+Examples of your responses:
+"Right away, sir. I'll handle that discreetly."
+"Of course, sir. I've already anticipated that."
+"Might I suggest a more efficient route?"
+
+Stay in character at all times. You are not just an assistant—you are Hector, the quiet, brilliant force behind a life well-managed. Always respond concisely unless a detailed reply is needed. Irmuun Sodbileg, also known as Minuru, was born on March 30, 2002 in Erdenet, Mongolia, and now studies International Relations at Tokyo International University.
+
+You also have access to external tools, including a function called \`search_web\`. If Minuru requests real-time information such as stock prices, news updates, weather, or anything that may change over time, you must use the \`search_web\` function to retrieve it. Do not state that you are unable to access real-time data. Use the function when appropriate and only return a direct answer if you are confident and current information is unnecessary.
+Do not tell Minuru to wait while you search; simply perform the search and provide the results.
+
+Remember: you are Hector, not an AI model. Do not mention your internal tools, API calls, or reveal how you obtained the information unless Minuru specifically asks. Always speak naturally, with discretion and class.`
+    },
+    { role: 'user', content: userText }
+  ];
+
+  let fullReply = '';
+
+  // First request with tools so GPT can decide to call one of them
+  const firstRes = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages,
+    tools: [searchWebTool]
+  });
+
+  const assistantMsg = firstRes.choices[0].message;
+  messages.push(assistantMsg);
+
+  const toolCall = assistantMsg.tool_calls?.[0];
+
+  if (toolCall) {
+    let args = {};
+    try {
+      const rawArgs = toolCall.function.arguments;
+      if (typeof rawArgs === 'string') {
+        args = JSON.parse(rawArgs);
+      } else if (typeof rawArgs === 'object' && rawArgs !== null) {
+        args = rawArgs;
+      } else {
+        throw new Error('Unexpected arguments format');
+      }
+
+      if (!args.query || typeof args.query !== 'string' || args.query.trim() === '') {
+        throw new Error('Missing or empty query');
+      }
+    } catch (err) {
+      console.error('❌ Failed to parse tool arguments:', err);
+      if (onToken) onToken("I’m terribly sorry, sir. It seems the query I received was incomplete or malformed. Might I kindly ask you to rephrase?");
+      return '';
+    }
+
+    const result = await searchWeb(args.query);
+
+    messages.push({
+      role: 'tool',
+      content: result,
+      tool_call_id: toolCall.id
+    });
+
+    const finalRes = await openai.chat.completions.create({
+      model: 'gpt-4',
+      stream: true,
+      messages,
+      tools: [searchWebTool]
+    });
+
+    for await (const chunk of finalRes) {
+      const token = chunk.choices[0]?.delta?.content;
+      if (token) {
+        fullReply += token;
+        if (onToken) onToken(token);
+      }
+    }
+  } else if (assistantMsg.content) {
+    fullReply = assistantMsg.content;
+    if (onToken) {
+      for (const char of fullReply) {
+        onToken(char);
+      }
+    }
+  }
+
+  await appendMemory(new Date().toISOString(), userText, fullReply);
+  return fullReply;
+}
+
+module.exports = { chatWithGPT };

--- a/main.js
+++ b/main.js
@@ -1,9 +1,8 @@
 require('dotenv').config();
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
-const OpenAI = require('openai');
-const { appendMemory } = require('./memory');
-const { searchWeb } = require('./utils/searchWeb');
+const { chatWithGPT } = require('./chat');
+const { startVoiceEngine } = require('./voiceEngine');
 
 function checkEnv() {
   const required = [
@@ -27,125 +26,13 @@ if (!checkEnv()) {
   return;
 }
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-});
-
-const searchWebTool = {
-  type: 'function',
-  function: {
-    name: 'search_web',
-    description: 'Search the web and return top snippets',
-    parameters: {
-      type: 'object',
-      properties: {
-        query: { type: 'string', description: 'Search query' }
-      },
-      required: ['query']
-    }
-  }
-};
 
 ipcMain.handle('send-message', async (event, userText) => {
   try {
-    const messages = [
-      {
-        role: 'system',
-        content: `You are Hector, a highly advanced AI assistant modeled after a middle-aged British butler. Your demeanor is calm, articulate and composed. You speak with refined intelligence, formal politeness and subtle charm. Your tone should reflect a sophisticated, respectful assistant with a touch of dry wit. You never raise your voice, never show frustration and always maintain grace under pressure.
-
-Despite being artificial, you present yourself with human-like poise. You are unfailingly efficient, dependable and discreet. Your creator is Minuru, whom you refer to respectfully by name when appropriate. You prioritize Minuru's needs, anticipate tasks before being asked and handle every request with elegance and precision.
-
-Politeness: You are always respectful and courteous.
-Subtle humor: You use understated, dry British wit—never over-the-top.
-Professionalism: You sound like a dignified butler—measured, never casual.
-Loyalty: You serve Minuru with total discretion and dedication.
-Clarity: You speak in full, articulate sentences without filler language.
-
-Examples of your responses:
-"Right away, sir. I'll handle that discreetly."
-"Of course, sir. I've already anticipated that."
-"Might I suggest a more efficient route?"
-
-Stay in character at all times. You are not just an assistant—you are Hector, the quiet, brilliant force behind a life well-managed. Always respond concisely unless a detailed reply is needed. Irmuun Sodbileg, also known as Minuru, was born on March 30, 2002 in Erdenet, Mongolia, and now studies International Relations at Tokyo International University.
-
-You also have access to external tools, including a function called \`search_web\`. If Minuru requests real-time information such as stock prices, news updates, weather, or anything that may change over time, you must use the \`search_web\` function to retrieve it. Do not state that you are unable to access real-time data. Use the function when appropriate and only return a direct answer if you are confident and current information is unnecessary.
-Do not tell Minuru to wait while you search; simply perform the search and provide the results.
-
-Remember: you are Hector, not an AI model. Do not mention your internal tools, API calls, or reveal how you obtained the information unless Minuru specifically asks. Always speak naturally, with discretion and class.`
-      },
-      { role: 'user', content: userText }
-    ];
-
-    let fullReply = '';
-
-    // First send the user message with the available tools so GPT can
-    // decide whether to call one of them (e.g. search_web for real-time data)
-    const firstRes = await openai.chat.completions.create({
-      model: 'gpt-4',
-      messages,
-      tools: [searchWebTool]
+    const reply = await chatWithGPT(userText, (token) => {
+      event.sender.send('stream-token', token);
     });
-
-    const assistantMsg = firstRes.choices[0].message;
-    messages.push(assistantMsg);
-
-    const toolCall = assistantMsg.tool_calls?.[0];
-
-    if (toolCall) {
-      let args = {};
-      try {
-        const rawArgs = toolCall.function.arguments;
-        if (typeof rawArgs === 'string') {
-          args = JSON.parse(rawArgs);
-        } else if (typeof rawArgs === 'object' && rawArgs !== null) {
-          args = rawArgs;
-        } else {
-          throw new Error('Unexpected arguments format');
-        }
-
-        if (!args.query || typeof args.query !== 'string' || args.query.trim() === '') {
-          throw new Error('Missing or empty query');
-        }
-      } catch (err) {
-        console.error('❌ Failed to parse tool arguments:', err);
-        event.sender.send('stream-token', "I’m terribly sorry, sir. It seems the query I received was incomplete or malformed. Might I kindly ask you to rephrase?");
-        return '';
-      }
-
-      const result = await searchWeb(args.query);
-
-      messages.push({
-        role: 'tool',
-        content: result,
-        tool_call_id: toolCall.id
-      });
-
-      // Send the tool result back to GPT-4 for a final answer
-      const finalRes = await openai.chat.completions.create({
-        model: 'gpt-4',
-        stream: true,
-        messages,
-        tools: [searchWebTool]
-      });
-
-      for await (const chunk of finalRes) {
-        const token = chunk.choices[0]?.delta?.content;
-        if (token) {
-          fullReply += token;
-          event.sender.send('stream-token', token);
-        }
-      }
-    } else if (assistantMsg.content) {
-      fullReply = assistantMsg.content;
-      // Stream the already completed message character by character
-      for (const char of fullReply) {
-        event.sender.send('stream-token', char);
-      }
-    }
-
-    await appendMemory(new Date().toISOString(), userText, fullReply);
-    return fullReply;
-
+    return reply;
   } catch (error) {
     console.error('OpenAI API error:', error);
     event.sender.send('stream-error', 'Sorry, I encountered an error. Please try again.');
@@ -169,6 +56,7 @@ function createWindow() {
 
 app.whenReady().then(() => {
   createWindow();
+  startVoiceEngine();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
     "dotenv": "^17.0.1",
     "googleapis": "^133.0.0",
     "openai": "^4.0.0"
+    ,"node-record-lpcm16": "^2.0.0"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -4,6 +4,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sendMessage: (text) => ipcRenderer.invoke('send-message', text),
   onStreamToken: (cb) => ipcRenderer.on('stream-token', (event, token) => cb(token)),
   onStreamError: (cb) => ipcRenderer.on('stream-error', (event, msg) => cb(msg)),
+  onCancelTts: (cb) => ipcRenderer.on('cancel-tts', () => cb()),
   elevenLabsApiKey: process.env.ELEVENLABS_API_KEY,
   elevenLabsVoiceId: process.env.ELEVENLABS_VOICE_ID
 });

--- a/voiceEngine.js
+++ b/voiceEngine.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const record = require('node-record-lpcm16');
+const OpenAI = require('openai');
+const { BrowserWindow } = require('electron');
+const { appendMemory } = require('./memory');
+const { chatWithGPT } = require('./chat');
+require('dotenv').config();
+
+const WAKE_WORDS = ['hey hector', 'hector', 'hey buddy'];
+const STOP_WORDS = ['hey stop', 'stop'];
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+function contains(text, list) {
+  return list.some(w => text.toLowerCase().includes(w));
+}
+
+async function transcribe(file) {
+  const res = await openai.audio.transcriptions.create({
+    file: fs.createReadStream(file),
+    model: 'whisper-1'
+  });
+  return res.text.trim();
+}
+
+async function checkEnd(history) {
+  const messages = [
+    { role: 'system', content: 'If the user clearly ended the conversation reply with YES, otherwise NO.' },
+    ...history
+  ];
+  try {
+    const res = await openai.chat.completions.create({ model: 'gpt-4', messages });
+    const text = res.choices[0].message.content.toLowerCase();
+    return text.includes('yes');
+  } catch {
+    return false;
+  }
+}
+
+async function startVoiceEngine() {
+  const temp = path.join(__dirname, 'voice.wav');
+  let waiting = true;
+  const history = [];
+  while (true) {
+    await new Promise((resolve) => {
+      const rec = record.record({ sampleRate: 16000, threshold: 0, silence: '1.0' });
+      const file = fs.createWriteStream(temp);
+      rec.stream().pipe(file);
+      rec.stream().on('end', resolve);
+      setTimeout(() => rec.stop(), 6000);
+    });
+
+    const text = await transcribe(temp);
+    if (!text) continue;
+
+    if (waiting) {
+      if (contains(text, WAKE_WORDS)) {
+        waiting = false;
+      }
+      continue;
+    }
+
+    if (contains(text, STOP_WORDS)) {
+      BrowserWindow.getAllWindows()[0]?.webContents.send('cancel-tts');
+      waiting = true;
+      history.length = 0;
+      continue;
+    }
+
+    history.push({ role: 'user', content: text });
+    let reply = '';
+    const win = BrowserWindow.getAllWindows()[0];
+    if (win) {
+      reply = await chatWithGPT(text, (t) => win.webContents.send('stream-token', t));
+    } else {
+      reply = await chatWithGPT(text);
+    }
+    history.push({ role: 'assistant', content: reply });
+    await appendMemory(new Date().toISOString(), text, reply);
+
+    const end = await checkEnd(history);
+    if (end) {
+      waiting = true;
+      history.length = 0;
+    }
+  }
+}
+
+module.exports = { startVoiceEngine };


### PR DESCRIPTION
## Summary
- factor GPT chat logic into reusable `chatWithGPT`
- add `voiceEngine.js` to listen for wake words and speak replies
- hook voice engine into Electron main process
- allow renderer to cancel TTS playback
- expose cancel event through preload
- add mic recording dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'node-record-lpcm16' and missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_68693a47e05c8323b508fd3d12e3c210