### PR TITLE
Use rec as record program

### DIFF
--- a/voiceEngine.js
+++ b/voiceEngine.js
@@ -115,10 +115,9 @@ async function startVoiceEngine() {
           sampleRate: 16000,
           channels: 1,
           audioType: 'wav',
-          recordProgram: 'sox',
+          recordProgram: 'rec',
           threshold: 0,
           verbose: true,
-          recorder: 'sox',
           device: RECORD_DEVICE,
           silence: '1.0'
         });


### PR DESCRIPTION
## Summary
- use `rec` command in voiceEngine instead of `sox`
- remove unused recorder option

## Testing
- `npm test`
- `node -e "const rec=require('node-record-lpcm16');rec.record({recordProgram:'rec'});"` *(fails: spawn sox ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686a47c200148323894c381c24f8e299