### PR TITLE
Add conversation mode toggle and improved self-transcription filter

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const { chatWithGPT } = require('./chat');
-const { startVoiceEngine } = require('./voiceEngine');
+const { startVoiceEngine, setConversationMode } = require('./voiceEngine');
 
 function checkEnv() {
   const required = [
@@ -43,6 +43,11 @@ ipcMain.handle('send-message', async (event, userText) => {
   }
 });
 
+ipcMain.on('toggle-conversation', (event, enabled) => {
+  setConversationMode(enabled);
+  BrowserWindow.getAllWindows().forEach(win => win.webContents.send('conversation-mode', enabled));
+});
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 800,
@@ -55,6 +60,9 @@ function createWindow() {
   });
 
   win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('conversation-mode', true);
+  });
 }
 
 app.whenReady().then(() => {

--- a/preload.js
+++ b/preload.js
@@ -7,6 +7,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onCancelTts: (cb) => ipcRenderer.on('cancel-tts', () => cb()),
   onVoiceText: (cb) => ipcRenderer.on('voice-text', (event, text) => cb(text)),
   onVoiceReply: (cb) => ipcRenderer.on('voice-reply', (event, reply) => cb(reply)),
+  toggleConversation: (enabled) => ipcRenderer.send('toggle-conversation', enabled),
+  onConversationMode: (cb) => ipcRenderer.on('conversation-mode', (event, mode) => cb(mode)),
   elevenLabsApiKey: process.env.ELEVENLABS_API_KEY,
   elevenLabsVoiceId: process.env.ELEVENLABS_VOICE_ID
 });

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -12,8 +12,9 @@
             <div class="avatar">AI</div>
             <div class="header-text">
                 <h1>Hector</h1>
-                <div class="status">Online</div>
+                <div class="status">Listening</div>
             </div>
+            <button id="conversation-toggle" class="toggle-button">Pause</button>
         </header>
         <div class="chat-window">
             <!-- Chat messages will be added dynamically -->

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -5,6 +5,8 @@ const {
     onCancelTts,
     onVoiceText,
     onVoiceReply,
+    toggleConversation,
+    onConversationMode,
     elevenLabsApiKey,
     elevenLabsVoiceId
 } = window.electronAPI
@@ -145,6 +147,23 @@ onVoiceReply((reply) => {
     if (currentAiMessage) {
         currentAiMessage.textContent = reply
     }
+})
+
+const statusEl = document.querySelector('.status')
+const toggleBtn = document.getElementById('conversation-toggle')
+let conversationEnabled = true
+
+toggleBtn.addEventListener('click', () => {
+    conversationEnabled = !conversationEnabled
+    toggleConversation(conversationEnabled)
+    toggleBtn.textContent = conversationEnabled ? 'Pause' : 'Resume'
+    statusEl.textContent = conversationEnabled ? 'Listening' : 'Standby'
+})
+
+onConversationMode((mode) => {
+    conversationEnabled = mode
+    toggleBtn.textContent = mode ? 'Pause' : 'Resume'
+    statusEl.textContent = mode ? 'Listening' : 'Standby'
 })
 
 document.querySelector('.chat-input-bar').addEventListener('submit', async (e) => {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -107,3 +107,18 @@ html, body {
 .send-button:hover {
     background: rgba(58,141,222,0.1);
 }
+
+.toggle-button {
+    margin-left: auto;
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.1);
+    color: #eee;
+    padding: 6px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.toggle-button:hover {
+    background: rgba(255,255,255,0.1);
+}


### PR DESCRIPTION
## Summary
- ignore self-transcription with a similarity check and log
- expose conversation mode control via IPC
- add toggle button to UI for conversation mode
- show current listening status in UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a523817c08323a643eeee6f345c89