### PR TITLE
Add universal clear-chat command

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,6 +48,11 @@ ipcMain.on('toggle-conversation', (event, enabled) => {
   BrowserWindow.getAllWindows().forEach(win => win.webContents.send('conversation-mode', enabled));
 });
 
+ipcMain.on('clear-chat', () => {
+  console.log('[hector] \ud83e\udd9a cleared chat history');
+  BrowserWindow.getAllWindows().forEach(win => win.webContents.send('clear-chat'));
+});
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 800,

--- a/preload.js
+++ b/preload.js
@@ -9,6 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onVoiceReply: (cb) => ipcRenderer.on('voice-reply', (event, reply) => cb(reply)),
   toggleConversation: (enabled) => ipcRenderer.send('toggle-conversation', enabled),
   onConversationMode: (cb) => ipcRenderer.on('conversation-mode', (event, mode) => cb(mode)),
+  onClearChat: (cb) => ipcRenderer.on('clear-chat', () => cb()),
+  clearChat: () => ipcRenderer.send('clear-chat'),
   elevenLabsApiKey: process.env.ELEVENLABS_API_KEY,
   elevenLabsVoiceId: process.env.ELEVENLABS_VOICE_ID
 });

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -7,6 +7,8 @@ const {
     onVoiceReply,
     toggleConversation,
     onConversationMode,
+    onClearChat,
+    clearChat,
     elevenLabsApiKey,
     elevenLabsVoiceId
 } = window.electronAPI
@@ -112,6 +114,23 @@ function queueToken(token) {
 const chatWindow = document.querySelector('.chat-window')
 let currentAiMessage = null
 
+function clearChatWindow() {
+    chatWindow.innerHTML = ''
+    currentAiMessage = null
+}
+
+onClearChat(() => {
+    clearChatWindow()
+})
+
+function isClearCommand(text) {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim() === 'hector delete the chats'
+}
+
 onStreamToken((token) => {
     if (currentAiMessage) {
         currentAiMessage.textContent += token
@@ -174,6 +193,13 @@ document.querySelector('.chat-input-bar').addEventListener('submit', async (e) =
     if (!userText) return
 
     input.value = ''
+
+    if (isClearCommand(userText)) {
+        console.log('[hector] \ud83e\udd9a cleared chat history')
+        clearChat()
+        clearChatWindow()
+        return
+    }
 
     const userMessage = document.createElement('div')
     userMessage.className = 'message user'

--- a/voiceEngine.js
+++ b/voiceEngine.js
@@ -63,6 +63,16 @@ function contains(text, list) {
   return list.some(w => text.toLowerCase().includes(w));
 }
 
+function isClearCommand(text) {
+  return (
+    text
+      .toLowerCase()
+      .replace(/[^a-z]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim() === 'hector delete the chats'
+  );
+}
+
 async function transcribe(file) {
   const res = await openai.audio.transcriptions.create({
     file: fs.createReadStream(file),
@@ -251,6 +261,14 @@ async function startVoiceEngine() {
 
     if (contains(text, STOP_WORDS)) {
       BrowserWindow.getAllWindows()[0]?.webContents.send('cancel-tts');
+      waiting = true;
+      history.length = 0;
+      continue;
+    }
+
+    if (isClearCommand(text)) {
+      console.log('[hector] \ud83e\udd9a cleared chat history');
+      BrowserWindow.getAllWindows().forEach(win => win.webContents.send('clear-chat'));
       waiting = true;
       history.length = 0;
       continue;


### PR DESCRIPTION
## Summary
- implement command for `Hector, delete the chats`
- broadcast clear-chat event from the main process
- expose `clearChat` helpers in the preload script
- update renderer to clear the chat window and skip message send
- detect spoken command in the voice engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a557c81008323936685609c63f61e