### PR TITLE
Add clear chat command handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ ipcMain.on('toggle-conversation', (event, enabled) => {
 });
 
 ipcMain.on('clear-chat', () => {
-  console.log('[hector] \ud83e\udd9a cleared chat history');
+  console.log('[hector] \ud83e\udd9a clearing chat');
   BrowserWindow.getAllWindows().forEach(win => win.webContents.send('clear-chat'));
 });
 

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -124,11 +124,13 @@ onClearChat(() => {
 })
 
 function isClearCommand(text) {
-    return text
+    const normalized = text
         .toLowerCase()
         .replace(/[^a-z]/g, ' ')
         .replace(/\s+/g, ' ')
-        .trim() === 'hector delete the chats'
+        .trim()
+    const phrases = ['delete chat', 'clear conversation', 'clear the chat']
+    return phrases.some(p => normalized === p || normalized === `hector ${p}`)
 }
 
 onStreamToken((token) => {
@@ -195,9 +197,8 @@ document.querySelector('.chat-input-bar').addEventListener('submit', async (e) =
     input.value = ''
 
     if (isClearCommand(userText)) {
-        console.log('[hector] \ud83e\udd9a cleared chat history')
+        console.log('[hector] \ud83e\udd9a clearing chat')
         clearChat()
-        clearChatWindow()
         return
     }
 

--- a/voiceEngine.js
+++ b/voiceEngine.js
@@ -64,13 +64,13 @@ function contains(text, list) {
 }
 
 function isClearCommand(text) {
-  return (
-    text
-      .toLowerCase()
-      .replace(/[^a-z]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim() === 'hector delete the chats'
-  );
+  const normalized = text
+    .toLowerCase()
+    .replace(/[^a-z]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const phrases = ['delete chat', 'clear conversation', 'clear the chat'];
+  return phrases.some(p => normalized === p || normalized === `hector ${p}`);
 }
 
 async function transcribe(file) {
@@ -267,7 +267,7 @@ async function startVoiceEngine() {
     }
 
     if (isClearCommand(text)) {
-      console.log('[hector] \ud83e\udd9a cleared chat history');
+      console.log('[hector] \ud83e\udd9a clearing chat');
       BrowserWindow.getAllWindows().forEach(win => win.webContents.send('clear-chat'));
       waiting = true;
       history.length = 0;


### PR DESCRIPTION
## Summary
- update clear chat log wording
- intercept clear commands typed or spoken
- look for `delete chat`, `clear conversation` and `clear the chat`

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a597849ec8323aed96d773d0e026b