### PR TITLE
Fix sandbox disable for preload scripts

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,7 +60,8 @@ function createWindow() {
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
-      nodeIntegration: false
+      nodeIntegration: false,
+      sandbox: false
     }
   });
 


### PR DESCRIPTION
## Summary
- disable sandbox for the BrowserWindow so the preload script can access Node modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a5e33ac1083239701eb80c789af8e