### PR TITLE
Handle local time and location queries

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -40,3 +40,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       })
     )
 });
+
+contextBridge.exposeInMainWorld('systemAPI', {
+  getTime: () => new Date().toString()
+});
+

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -11,13 +11,14 @@ const {
     clearChat,
     elevenLabsApiKey,
     elevenLabsVoiceId,
-    getTime,
     getUser,
     listDir,
     readFile,
     writeFile,
     run
 } = window.electronAPI
+
+const { getTime } = window.systemAPI
 
 let audioQueue = Promise.resolve()
 let currentAudio = null
@@ -166,8 +167,14 @@ function addAssistantMessage(text) {
 async function handleLocalCommand(text) {
     const lower = text.toLowerCase().trim()
     if (lower === 'what time is it') {
-        const time = await getTime()
+        console.log('[hector] answering from local APIs: time request')
+        const time = getTime()
         addAssistantMessage(time)
+        return true
+    }
+    if (lower === 'where am i') {
+        console.log('[hector] answering from local APIs: location request')
+        addAssistantMessage('Location access not enabled')
         return true
     }
     if (lower.includes('list') && lower.includes('desktop')) {


### PR DESCRIPTION
## Summary
- expose `systemAPI.getTime` in the preload script
- intercept `what time is it` and `where am I` in the renderer
- answer from local APIs instead of sending these to GPT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a7d3fdee88323b0c01a6b5541777d