### PR TITLE
Improve speech buffering

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -126,8 +126,10 @@ function flushBuffer() {
 
 function queueToken(token) {
     buffered += token
-    const words = buffered.trim().split(/\s+/).filter(Boolean)
-    if (words.length >= 3) {
+    const trimmed = buffered.trim()
+    const endsWithPunct = /[.!?]$/.test(trimmed)
+    const exceedsLength = trimmed.length >= 120
+    if (endsWithPunct || exceedsLength) {
         pendingText += buffered
         buffered = ''
         processQueue()


### PR DESCRIPTION
## Summary
- delay flushing speech tokens until punctuation appears
- add backup flush when buffer reaches 120 chars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b972a5aac8323b9749c5583cd0a4a