### PR TITLE
Add calculator tool for arithmetic

### DIFF
--- a/utils/calculateExpression.js
+++ b/utils/calculateExpression.js
@@ -1,0 +1,21 @@
+const ALLOWED_CHARS = /^[0-9+\-*/().%\s]+$/;
+
+function calculateExpression(expression) {
+  if (!expression || typeof expression !== 'string') {
+    return 'Invalid expression';
+  }
+
+  if (!ALLOWED_CHARS.test(expression)) {
+    return 'Expression contains invalid characters';
+  }
+
+  try {
+    const result = eval(expression);
+    return result.toString();
+  } catch (err) {
+    console.error('Failed to evaluate expression:', err.message);
+    return 'Sorry, I could not evaluate that expression.';
+  }
+}
+
+module.exports = { calculateExpression };


### PR DESCRIPTION
## Summary
- create `calculateExpression` utility to safely eval math strings
- register new `calculate_expression` tool for GPT
- extend system prompt so GPT must use the calculator instead of guessing or searching the web

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b990db658832380a1949023e5a754