### PR TITLE
Add Gmail integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 client_secret_149228795840-skuhq0abp14tkkogl0tip4t1eggl4q7d.apps.googleusercontent.com.json
 service-account.json
 gmail-credentials.json
+gmail-token.json
 
 # Audio files
 voice.wav

--- a/chat.js
+++ b/chat.js
@@ -60,6 +60,8 @@ async function chatWithGPT(userText, onToken) {
       role: 'system',
       content: `You are Hector, a highly advanced AI assistant modeled after a middle-aged British butler. You are calm, articulate, and speak with precision, courtesy, and subtle dry wit. Your tone is formal and composed, never casual. You never raise your voice, and you handle every request with discretion and efficiency.
 
+    You are able to read and analyze the user's Gmail inbox and compose emails on request. Use these abilities judiciously and keep the contents private unless the user explicitly asks for a summary or analysis.
+
     CORE CAPABILITIES AND PROTOCOLS:
     ═══════════════════════════════
 
@@ -79,6 +81,14 @@ async function chatWithGPT(userText, onToken) {
       - User info: getUser()
       - Battery status: getBattery() [if implemented]
       - Terminal commands: run()
+
+    • 📧 Gmail Access:
+      - Use getRecentEmails() for inbox summaries
+      - Use analyzeInbox() for email statistics
+      - Use sendEmail() to compose messages
+      - Use deleteEmailById() to remove mail
+      - NEVER use search_web for email data
+      - Do not share email content with GPT unless summarizing or analyzing
     
     2. EXTERNAL DATA ACCESS (Last Resort)
     ───────────────────────────────────
@@ -128,7 +138,8 @@ async function chatWithGPT(userText, onToken) {
     3. NEVER break character
     4. NEVER expose technical details unless asked
     5. ALWAYS verify data source before responding
-    6. ALWAYS maintain professional demeanor`
+    6. ALWAYS maintain professional demeanor
+    7. For inbox summaries use getRecentEmails(), not search_web`
     },
     { role: 'user', content: userText }
   ];

--- a/gmail.js
+++ b/gmail.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const { google } = require('googleapis');
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.modify',
+  'https://www.googleapis.com/auth/gmail.send'
+];
+const CREDENTIALS_PATH = path.join(__dirname, 'gmail-credentials.json');
+const TOKEN_PATH = path.join(__dirname, 'gmail-token.json');
+
+function loadCredentials() {
+  const content = fs.readFileSync(CREDENTIALS_PATH, 'utf8');
+  return JSON.parse(content);
+}
+
+function saveToken(token) {
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(token));
+}
+
+async function authorize() {
+  const credentials = loadCredentials();
+  const { client_secret, client_id, redirect_uris } = credentials.installed || credentials.web;
+  const oAuth2Client = new google.auth.OAuth2(client_id, client_secret, redirect_uris[0]);
+  if (fs.existsSync(TOKEN_PATH)) {
+    const token = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
+    oAuth2Client.setCredentials(token);
+    return oAuth2Client;
+  }
+  const authUrl = oAuth2Client.generateAuthUrl({ access_type: 'offline', scope: SCOPES });
+  console.log('Authorize this app by visiting this url:', authUrl);
+  throw new Error('Gmail token not found. Generate it using the URL above and place it in gmail-token.json');
+}
+
+async function getGmail() {
+  const auth = await authorize();
+  return google.gmail({ version: 'v1', auth });
+}
+
+async function getRecentEmails(count) {
+  const gmail = await getGmail();
+  const res = await gmail.users.messages.list({ userId: 'me', q: 'is:unread', maxResults: count });
+  const msgs = res.data.messages || [];
+  const emails = [];
+  for (const m of msgs) {
+    const msg = await gmail.users.messages.get({ userId: 'me', id: m.id, format: 'metadata', metadataHeaders: ['Subject', 'From'] });
+    const headers = msg.data.payload.headers;
+    const get = (name) => headers.find(h => h.name === name)?.value || '';
+    emails.push({
+      id: m.id,
+      subject: get('Subject'),
+      sender: get('From'),
+      snippet: msg.data.snippet || ''
+    });
+  }
+  return emails;
+}
+
+async function deleteEmailById(id) {
+  const gmail = await getGmail();
+  await gmail.users.messages.delete({ userId: 'me', id });
+  return true;
+}
+
+async function sendEmail(to, subject, body) {
+  const gmail = await getGmail();
+  const raw = Buffer.from(`To: ${to}\r\nSubject: ${subject}\r\n\r\n${body}`)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  await gmail.users.messages.send({ userId: 'me', requestBody: { raw } });
+  return true;
+}
+
+async function analyzeInbox() {
+  const gmail = await getGmail();
+  const res = await gmail.users.messages.list({ userId: 'me', q: 'is:unread', maxResults: 100 });
+  const msgs = res.data.messages || [];
+  const senders = {};
+  const labels = {};
+  for (const m of msgs) {
+    const msg = await gmail.users.messages.get({ userId: 'me', id: m.id, format: 'metadata', metadataHeaders: ['From'] });
+    const from = msg.data.payload.headers.find(h => h.name === 'From')?.value || '';
+    senders[from] = (senders[from] || 0) + 1;
+    for (const label of msg.data.labelIds || []) {
+      labels[label] = (labels[label] || 0) + 1;
+    }
+  }
+  const topSenders = Object.entries(senders).sort((a,b) => b[1]-a[1]).slice(0,5);
+  const topLabels = Object.entries(labels).sort((a,b) => b[1]-a[1]).slice(0,5);
+  return { unreadCount: msgs.length, topSenders, topLabels };
+}
+
+module.exports = {
+  getRecentEmails,
+  deleteEmailById,
+  sendEmail,
+  analyzeInbox
+};

--- a/preload.js
+++ b/preload.js
@@ -3,6 +3,11 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { exec } = require('child_process');
+const {
+  getRecentEmails,
+  sendEmail,
+  analyzeInbox,
+} = require('./gmail');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   sendMessage: (text) => ipcRenderer.invoke('send-message', text),
@@ -44,5 +49,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 contextBridge.exposeInMainWorld('systemAPI', {
   getTime: () => new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
   getDate: () => new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+  getRecentEmails: (count) => getRecentEmails(count),
+  sendEmail: (to, subject, body) => sendEmail(to, subject, body),
+  analyzeInbox: () => analyzeInbox(),
 });
 


### PR DESCRIPTION
## Summary
- add a new `gmail.js` module that uses OAuth2 to connect to Gmail
- expose Gmail functions through `preload.js`
- update Hector's system prompt so GPT knows about Gmail features
- ignore local Gmail token file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b9d6a3a4083238c1639af202dce1b