### PR TITLE
Add Gmail OAuth handling in main process

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,11 @@ const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 const { chatWithGPT } = require('./chat');
 const { startVoiceEngine, setConversationMode } = require('./voiceEngine');
+const {
+  getRecentEmails,
+  sendEmail,
+  analyzeInbox,
+} = require('./gmail');
 
 function checkEnv() {
   const required = [
@@ -41,6 +46,18 @@ ipcMain.handle('send-message', async (event, userText) => {
     event.sender.send('stream-error', 'Sorry, I encountered an error. Please try again.');
     return '';
   }
+});
+
+ipcMain.handle('get-recent-emails', async (_event, count) => {
+  return getRecentEmails(count);
+});
+
+ipcMain.handle('send-email', async (_event, to, subject, body) => {
+  return sendEmail(to, subject, body);
+});
+
+ipcMain.handle('analyze-inbox', async () => {
+  return analyzeInbox();
 });
 
 ipcMain.on('toggle-conversation', (event, enabled) => {

--- a/preload.js
+++ b/preload.js
@@ -3,11 +3,6 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { exec } = require('child_process');
-const {
-  getRecentEmails,
-  sendEmail,
-  analyzeInbox,
-} = require('./gmail');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   sendMessage: (text) => ipcRenderer.invoke('send-message', text),
@@ -49,8 +44,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 contextBridge.exposeInMainWorld('systemAPI', {
   getTime: () => new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
   getDate: () => new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
-  getRecentEmails: (count) => getRecentEmails(count),
-  sendEmail: (to, subject, body) => sendEmail(to, subject, body),
-  analyzeInbox: () => analyzeInbox(),
+  getRecentEmails: (count) => ipcRenderer.invoke('get-recent-emails', count),
+  sendEmail: (to, subject, body) =>
+    ipcRenderer.invoke('send-email', to, subject, body),
+  analyzeInbox: () => ipcRenderer.invoke('analyze-inbox'),
 });
 


### PR DESCRIPTION
## Summary
- prompt for Gmail authorization when token is missing
- store the authorized client and reuse it
- expose Gmail functions from the main process via IPC
- call Gmail IPC methods from the preload script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ba1ab98508323943779166ec53e66