### PR TITLE
Update Gmail fetch to show inbox emails

### DIFF
--- a/gmail.js
+++ b/gmail.js
@@ -73,7 +73,7 @@ async function getGmail() {
 
 async function getRecentEmails(count) {
   const gmail = await getGmail();
-  const res = await gmail.users.messages.list({ userId: 'me', q: 'is:unread', maxResults: count });
+  const res = await gmail.users.messages.list({ userId: 'me', labelIds: ['INBOX'], maxResults: count });
   const msgs = res.data.messages || [];
   const emails = [];
   for (const m of msgs) {


### PR DESCRIPTION
## Summary
- modify `getRecentEmails` in `gmail.js` to fetch messages from the Inbox instead of only unread ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb03f7ae8832386f55a3a881bc2da