### PR TITLE
Improve Gmail OAuth setup and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ request is sent without them. Web search requires `GOOGLE_API_KEY` and
 1. Copy `.env.example` to `.env`.
 2. Replace the example values in `.env` with your own keys. Set `ELEVENLABS_API_KEY` and `ELEVENLABS_VOICE_ID` for speech, and `GOOGLE_API_KEY` with `GOOGLE_CSE_ID` for web search.
 3. Install dependencies with `npm install`.
-4. Install SoX for audio recording (for example, `brew install sox`). Run `sox --version` to check that it works. If your computer asks for microphone access, allow it so recording can start.
-5. Make sure the `wav` package is installed; it encodes the microphone input as a proper WAV file.
-6. Start the app with `npm start`.
+4. Download a Gmail OAuth client JSON from the Google Cloud console and save it as `gmail-credentials.json` in this folder. Then run `node gmail.js` once and follow the link to grant access. This creates `gmail-token.json` so Hector can read your inbox.
+5. Install SoX for audio recording (for example, `brew install sox`). Run `sox --version` to check that it works. If your computer asks for microphone access, allow it so recording can start.
+6. Make sure the `wav` package is installed; it encodes the microphone input as a proper WAV file.
+7. Start the app with `npm start`.

--- a/gmail.js
+++ b/gmail.js
@@ -12,6 +12,11 @@ const CREDENTIALS_PATH = path.join(__dirname, 'gmail-credentials.json');
 const TOKEN_PATH = path.join(__dirname, 'gmail-token.json');
 
 function loadCredentials() {
+  if (!fs.existsSync(CREDENTIALS_PATH)) {
+    throw new Error(
+      `Gmail credentials not found. Please place your OAuth client JSON at ${CREDENTIALS_PATH}.`
+    );
+  }
   const content = fs.readFileSync(CREDENTIALS_PATH, 'utf8');
   return JSON.parse(content);
 }
@@ -26,10 +31,11 @@ async function authorize() {
   const credentials = loadCredentials();
   const { client_secret, client_id, redirect_uris } =
     credentials.installed || credentials.web;
+  const redirectUri = (redirect_uris && redirect_uris[0]) || 'urn:ietf:wg:oauth:2.0:oob';
   const oAuth2Client = new google.auth.OAuth2(
     client_id,
     client_secret,
-    'urn:ietf:wg:oauth:2.0:oob'
+    redirectUri
   );
 
   if (fs.existsSync(TOKEN_PATH)) {


### PR DESCRIPTION
## Summary
- mention Gmail OAuth setup in README so Hector can access Gmail
- validate gmail credentials file exists
- use first redirect URI from credentials for OAuth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb1fa08c88323aed4b97f9817477c