### PR TITLE
Handle getRecentEmails tool in stream

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -200,11 +200,13 @@ onStreamToken((token) => {
             try {
                 const emails = await getRecentEmails(3)
                 for (const mail of emails) {
-                    const text = `\u2709\ufe0f *${mail.subject}*\nFrom: ${mail.sender}\n${mail.snippet}`
+                    const text = `Here's a recent email:\nSubject: ${mail.subject}\nFrom: ${mail.sender}\n${mail.snippet}`
                     addAssistantMessage(text)
                 }
             } catch (err) {
-                addAssistantMessage('Failed to fetch recent emails')
+                addAssistantMessage('Sorry, I could not fetch your recent emails.')
+            } finally {
+                emailToolRequested = false
             }
         })()
     }


### PR DESCRIPTION
## Summary
- call `getRecentEmails` as soon as token mentions the tool
- format polite message per email
- reset `emailToolRequested` once emails are fetched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb737c6388323bc95a3663ac28d9b