### PR TITLE
Add Google Calendar support

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -69,6 +69,21 @@ const getRecentEmailsTool = {
   }
 };
 
+const getCalendarEventsTool = {
+  type: 'function',
+  function: {
+    name: 'get_calendar_events',
+    description: 'Fetch upcoming events from the user\'s Google Calendar',
+    parameters: {
+      type: 'object',
+      properties: {
+        count: { type: 'integer', description: 'Number of events to fetch (default is 3)' }
+      },
+      required: ['count']
+    }
+  }
+};
+
 const sendEmailTool = {
   type: 'function',
   function: {
@@ -182,7 +197,15 @@ async function chatWithGPT(userText, onToken) {
   const firstRes = await openai.chat.completions.create({
     model: 'gpt-4',
     messages,
-    tools: [searchWebTool, getTimeTool, getDateTool, calculateExpressionTool, getRecentEmailsTool, sendEmailTool]
+    tools: [
+      searchWebTool,
+      getTimeTool,
+      getDateTool,
+      calculateExpressionTool,
+      getRecentEmailsTool,
+      sendEmailTool,
+      getCalendarEventsTool
+    ]
   });
 
   const assistantMsg = firstRes.choices[0].message;
@@ -196,6 +219,8 @@ async function chatWithGPT(userText, onToken) {
     
     if (name === 'getRecentEmails' && onToken) {
       onToken('[TOOL:getRecentEmails]');
+    } else if (name === 'get_calendar_events' && onToken) {
+      onToken('[TOOL:get_calendar_events]');
     }
     
     let result = '';
@@ -249,6 +274,8 @@ async function chatWithGPT(userText, onToken) {
       result = calculateExpression(args.expression);
     } else if (name === 'getRecentEmails') {
       result = '[EMAILS]';
+    } else if (name === 'get_calendar_events') {
+      result = '[EVENTS]';
     } else if (name === 'send_email') {
       let args = {};
       try {
@@ -274,7 +301,15 @@ async function chatWithGPT(userText, onToken) {
         model: 'gpt-4',
         stream: true,
         messages,
-        tools: [searchWebTool, getTimeTool, getDateTool, calculateExpressionTool, getRecentEmailsTool, sendEmailTool]
+        tools: [
+          searchWebTool,
+          getTimeTool,
+          getDateTool,
+          calculateExpressionTool,
+          getRecentEmailsTool,
+          sendEmailTool,
+          getCalendarEventsTool
+        ]
       });
 
       for await (const chunk of finalRes) {

--- a/main.js
+++ b/main.js
@@ -8,6 +8,10 @@ const {
   sendEmail,
   analyzeInbox,
 } = require('./gmail');
+const {
+  getUpcomingEvents,
+  createEvent,
+} = require('./utils/calendar');
 
 function checkEnv() {
   const required = [
@@ -52,6 +56,16 @@ ipcMain.handle('get-recent-emails', async (_event, count) => {
   const num = Number.isInteger(count) ? count : parseInt(count, 10);
   const safeCount = Math.min(Math.max(num || 3, 1), 20);
   return getRecentEmails(safeCount);
+});
+
+ipcMain.handle('get-upcoming-events', async (_event, count) => {
+  const num = Number.isInteger(count) ? count : parseInt(count, 10);
+  const safeCount = Math.min(Math.max(num || 3, 1), 20);
+  return getUpcomingEvents(safeCount);
+});
+
+ipcMain.handle('create-event', async (_event, details) => {
+  return createEvent(details);
 });
 
 ipcMain.handle('send-email', async (_event, to, subject, body) => {

--- a/preload.js
+++ b/preload.js
@@ -35,6 +35,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Request recent emails through the main process
   // Expose the same helper on systemAPI
   getRecentEmails: (count) => ipcRenderer.invoke('get-recent-emails', count),
+  getUpcomingEvents: (count) => ipcRenderer.invoke('get-upcoming-events', count),
+  createEvent: (details) => ipcRenderer.invoke('create-event', details),
   run: (cmd) =>
     new Promise((resolve) =>
       exec(cmd, (error, stdout, stderr) => {
@@ -48,6 +50,8 @@ contextBridge.exposeInMainWorld('systemAPI', {
   getTime: () => new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
   getDate: () => new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
   getRecentEmails: (count) => ipcRenderer.invoke('get-recent-emails', count),
+  getUpcomingEvents: (count) => ipcRenderer.invoke('get-upcoming-events', count),
+  createEvent: (details) => ipcRenderer.invoke('create-event', details),
   sendEmail: (to, subject, body) =>
     ipcRenderer.invoke('send-email', to, subject, body),
   analyzeInbox: () => ipcRenderer.invoke('analyze-inbox'),

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -1,0 +1,121 @@
+const fs = require('fs');
+const path = require('path');
+const { google } = require('googleapis');
+const readline = require('readline');
+
+const SCOPES = ['https://www.googleapis.com/auth/calendar'];
+const CREDENTIALS_PATH = path.join(__dirname, 'calendar-credentials.json');
+const TOKEN_PATH = path.join(__dirname, 'calendar-token.json');
+
+function loadCredentials() {
+  if (!fs.existsSync(CREDENTIALS_PATH)) {
+    throw new Error(
+      `Calendar credentials not found. Please place your OAuth client JSON at ${CREDENTIALS_PATH}.`
+    );
+  }
+  const content = fs.readFileSync(CREDENTIALS_PATH, 'utf8');
+  return JSON.parse(content);
+}
+
+function saveToken(token) {
+  fs.writeFileSync(TOKEN_PATH, JSON.stringify(token));
+}
+
+let cachedClient = null;
+
+async function authorize() {
+  const credentials = loadCredentials();
+  const { client_secret, client_id, redirect_uris } =
+    credentials.installed || credentials.web;
+  const redirectUri = (redirect_uris && redirect_uris[0]) || 'urn:ietf:wg:oauth:2.0:oob';
+  const oAuth2Client = new google.auth.OAuth2(
+    client_id,
+    client_secret,
+    redirectUri
+  );
+
+  if (fs.existsSync(TOKEN_PATH)) {
+    const token = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
+    oAuth2Client.setCredentials(token);
+    cachedClient = oAuth2Client;
+    return oAuth2Client;
+  }
+
+  const authUrl = oAuth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+  });
+  console.log('Please visit this URL to connect Google Calendar:\n', authUrl);
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const code = await new Promise((resolve) =>
+    rl.question('Enter the code from that page here: ', (input) => {
+      rl.close();
+      resolve(input.trim());
+    })
+  );
+
+  const { tokens } = await oAuth2Client.getToken(code);
+  oAuth2Client.setCredentials(tokens);
+  saveToken(tokens);
+  cachedClient = oAuth2Client;
+  return oAuth2Client;
+}
+
+async function getCalendar() {
+  if (!cachedClient) {
+    cachedClient = await authorize();
+  }
+  return google.calendar({ version: 'v3', auth: cachedClient });
+}
+
+async function getUpcomingEvents(count) {
+  const calendar = await getCalendar();
+  const res = await calendar.events.list({
+    calendarId: 'primary',
+    timeMin: new Date().toISOString(),
+    maxResults: count,
+    singleEvents: true,
+    orderBy: 'startTime',
+  });
+  const events = res.data.items || [];
+  return events.map((ev) => ({
+    id: ev.id,
+    summary: ev.summary || '',
+    start: ev.start.dateTime || ev.start.date,
+    end: ev.end.dateTime || ev.end.date,
+    description: ev.description || '',
+    location: ev.location || '',
+  }));
+}
+
+async function createEvent({ summary, start, end, description, location }) {
+  const calendar = await getCalendar();
+  const event = {
+    summary,
+    start: { dateTime: start },
+    end: { dateTime: end },
+    description,
+    location,
+  };
+  const res = await calendar.events.insert({
+    calendarId: 'primary',
+    requestBody: event,
+  });
+  return res.data;
+}
+
+module.exports = {
+  getUpcomingEvents,
+  createEvent,
+};
+
+if (require.main === module) {
+  authorize()
+    .then(() => console.log('✅ Calendar authorization complete.'))
+    .catch((err) => console.error('❌ Authorization failed:', err));
+}


### PR DESCRIPTION
## Summary
- add `utils/calendar.js` to handle Calendar OAuth and events
- expose calendar functions in `main.js` IPC and preload bridge
- register `get_calendar_events` tool for GPT in chat flow
- stream calendar summaries when the tool is used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5d4559f88323af50a22033be9e44