### PR TITLE
Add calendar event deletion and concise prompt

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const {
 const {
   getUpcomingEvents,
   createEvent,
+  deleteEvent
 } = require('./utils/calendar');
 
 function checkEnv() {
@@ -72,6 +73,10 @@ ipcMain.handle('create-event', async (_event, details) => {
     details.end,
     details.calendarId || 'primary'
   );
+});
+
+ipcMain.handle('delete-event', async (_event, eventId) => {
+  return deleteEvent(eventId);
 });
 
 ipcMain.handle('send-email', async (_event, to, subject, body) => {

--- a/preload.js
+++ b/preload.js
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getRecentEmails: (count) => ipcRenderer.invoke('get-recent-emails', count),
   getUpcomingEvents: (count) => ipcRenderer.invoke('get-upcoming-events', count),
   createEvent: (details) => ipcRenderer.invoke('create-event', details),
+  deleteEvent: (id) => ipcRenderer.invoke('delete-event', id),
   run: (cmd) =>
     new Promise((resolve) =>
       exec(cmd, (error, stdout, stderr) => {
@@ -52,6 +53,7 @@ contextBridge.exposeInMainWorld('systemAPI', {
   getRecentEmails: (count) => ipcRenderer.invoke('get-recent-emails', count),
   getUpcomingEvents: (count) => ipcRenderer.invoke('get-upcoming-events', count),
   createEvent: (details) => ipcRenderer.invoke('create-event', details),
+  deleteEvent: (id) => ipcRenderer.invoke('delete-event', id),
   sendEmail: (to, subject, body) =>
     ipcRenderer.invoke('send-email', to, subject, body),
   analyzeInbox: () => ipcRenderer.invoke('analyze-inbox'),

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -87,10 +87,23 @@ async function createEvent(
   }
 }
 
+async function deleteEvent(eventId, calendarId = 'primary') {
+  try {
+    const calendar = await getCalendar();
+    await calendar.events.delete({ calendarId, eventId });
+    console.log('✅ Event deleted:', eventId);
+    return true;
+  } catch (err) {
+    console.error('❌ Failed to delete calendar event:', err.message);
+    return false;
+  }
+}
+
 module.exports = {
   getUpcomingEvents,
   listCalendars,
-  createEvent
+  createEvent,
+  deleteEvent
 };
 
 // Allow manual testing


### PR DESCRIPTION
## Summary
- implement `deleteEvent` to remove Google Calendar events
- wire `deleteEvent` through IPC and preload
- expose new `delete_event` tool in Hector
- instruct Hector to keep responses short and practical

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68742a2933a48323815326ec314d132f