### PR TITLE
Fix deletion prompt instructions

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -190,9 +190,10 @@ async function chatWithGPT(userText, onToken) {
       - NEVER use search_web for email data
       - Do not share email content with GPT unless summarizing or analyzing
     • 🗓 Calendar Access:
-      - Use get_calendar_events() for upcoming events
-      - Use createEvent() to add events
-      - Use deleteEvent() to remove events
+      - Use get_calendar_events() only to list upcoming events
+      - Use create_event() to add events
+      - Use delete_event() to remove events
+        • When asked to delete or remove an event or reminder (e.g. "delete the shopping reminder" or "delete all reminders"), call delete_event with the title, time, or event ID. Do NOT call get_calendar_events for deletions.
     • 🧠 Memory Log:
       - Use read_recent_memory() to recall past conversation entries
     
@@ -226,6 +227,7 @@ async function chatWithGPT(userText, onToken) {
     ══════════════════
     • Tone: Formal, courteous, with subtle wit
     • Style: Clear and brief. Reply with short statements like "Done, sir." or "Marked for 5 PM."
+    • Always keep responses short and direct; avoid overly formal or long-winded replies
     • Character: Always maintain butler persona
     • APIs: Never mention technical details unless asked
     • Errors: Handle with grace and offer alternatives


### PR DESCRIPTION
## Summary
- clarify use of `delete_event` in system instructions
- emphasize concise responses
- ensure `delete_event` tool included in chat completions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874eecc735083239eb3421e577874c8