### PR TITLE
Improve calendar deletion reliability

### DIFF
--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -22,6 +22,7 @@ async function getUpcomingEvents(count = 3) {
 
   const events = res.data.items || [];
   return events.map((e) => ({
+    id: e.id,
     summary: e.summary || 'No Title',
     start: e.start?.dateTime || e.start?.date || 'No Start Time',
     description: e.description || '',


### PR DESCRIPTION
## Summary
- include event IDs when listing calendar events
- keep a cache of the last listed events
- delete events using the cached IDs
- document new calendar deletion workflow

## Testing
- `npm test`
- `node test-calendar.js` *(fails: Credentials file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f0d46f488323852bb7d52075b55d