### PR TITLE
Fix calendar time parsing and deletion

### DIFF
--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -24,8 +24,7 @@ async function getUpcomingEvents(count = 3) {
   return events.map((e) => ({
     id: e.id,
     summary: e.summary || 'No Title',
-    start: e.start?.dateTime || e.start?.date || 'No Start Time',
-    description: e.description || '',
+    start: e.start?.dateTime || e.start?.date || '',
   }));
 }
 

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,8 +1,32 @@
+function toLocalISOString(date) {
+  const tzOffset = -date.getTimezoneOffset();
+  const sign = tzOffset >= 0 ? '+' : '-';
+  const pad = (n) => String(Math.floor(Math.abs(n))).padStart(2, '0');
+  return (
+    date.getFullYear() +
+    '-' +
+    pad(date.getMonth() + 1) +
+    '-' +
+    pad(date.getDate()) +
+    'T' +
+    pad(date.getHours()) +
+    ':' +
+    pad(date.getMinutes()) +
+    ':' +
+    pad(date.getSeconds()) +
+    sign +
+    pad(tzOffset / 60) +
+    ':' +
+    pad(tzOffset % 60)
+  );
+}
+
 function parseTimeToday(text) {
   if (!text) return null;
 
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const match = String(text).trim().match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i);
+  const match = String(text)
+    .trim()
+    .match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i);
   if (!match) return null;
 
   let hour = parseInt(match[1], 10);
@@ -13,19 +37,16 @@ function parseTimeToday(text) {
   if (period === 'am' && hour === 12) hour = 0;
 
   const now = new Date();
-  const startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute, 0);
-  const endDate = new Date(startDate.getTime() + 60 * 60 * 1000);
+  const date = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    hour,
+    minute,
+    0
+  );
 
-  return {
-    start: {
-      dateTime: startDate.toISOString(),
-      timeZone
-    },
-    end: {
-      dateTime: endDate.toISOString(),
-      timeZone
-    }
-  };
+  return toLocalISOString(date);
 }
 
-module.exports = { parseTimeToday };
+module.exports = { parseTimeToday, toLocalISOString };


### PR DESCRIPTION
## Summary
- improve time parsing helper to return ISO with local timezone
- adjust event creation to use local timezone string
- cache upcoming events with start, summary, and id
- delete events by id, index, or title from cached results

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687503683e988323ac1bd97ffa4f5283