### PR TITLE
Adjust environment handling and scripts

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
+const isDev = process.env.NODE_ENV === 'development';
 const { chatWithGPT } = require('./chat');
 const { startVoiceEngine, setConversationMode } = require('./voiceEngine');
 const { readRecentMemory } = require('./memory');
@@ -118,7 +119,6 @@ function createWindow() {
     }
   });
 
-  const isDev = process.env.NODE_ENV === 'development';
   if (isDev) {
     win.loadURL('http://localhost:3000');
   } else {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "setup": "npm install && npm --prefix renderer install",
-    "dev": "NODE_ENV=development npm --prefix renderer run dev & electron .",
-    "build": "npm --prefix renderer run build && npm --prefix renderer run export",
+    "dev": "NODE_ENV=development npm --prefix renderer run dev & NODE_ENV=development electron .",
+    "build": "npm --prefix renderer run build",
     "start": "NODE_ENV=production electron .",
     "test": "echo \"No tests defined yet\" && exit 0"
   },

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -3,11 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
-    "export": "next export",
+    "setup": "npm install",
     "dev": "next dev",
-    "start": "next start",
-    "build:prod": "npm run build && npm run export"
+    "build": "next build && next export",
+    "start": "next start"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- detect development mode at startup
- load Next.js dev server when `NODE_ENV` is development
- load static build when in production
- streamline build steps for renderer
- keep setup, dev, build and start tasks in both root and renderer

## Testing
- `npm test`
- `npm --prefix renderer test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687561d325c88323b214dd64841ac885