### PR TITLE
Set up React dashboard with react-grid-layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,7 +116,12 @@ function createWindow() {
     }
   });
 
-  win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  const isDev = !app.isPackaged;
+  if (isDev) {
+    win.loadURL('http://localhost:3000');
+  } else {
+    win.loadFile(path.join(__dirname, 'renderer', 'react-ui', 'build', 'index.html'));
+  }
   win.webContents.on('did-finish-load', () => {
     win.webContents.send('conversation-mode', true);
   });

--- a/renderer/react-ui/.gitignore
+++ b/renderer/react-ui/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/build

--- a/renderer/react-ui/package.json
+++ b/renderer/react-ui/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-grid-layout": "^1.3.4",
+    "web-vitals": "^2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": ["react-app", "react-app/jest"]
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  }
+}

--- a/renderer/react-ui/public/index.html
+++ b/renderer/react-ui/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hector Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/renderer/react-ui/src/Dashboard.css
+++ b/renderer/react-ui/src/Dashboard.css
@@ -1,0 +1,26 @@
+.layout {
+  background: #1e1e1e;
+  min-height: 100vh;
+}
+
+.widget {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  backdrop-filter: blur(10px);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.widget-header {
+  cursor: move;
+  padding: 8px;
+  font-weight: bold;
+  background: rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.widget-body {
+  padding: 8px;
+  flex: 1;
+}

--- a/renderer/react-ui/src/Dashboard.jsx
+++ b/renderer/react-ui/src/Dashboard.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import GridLayout from 'react-grid-layout';
+import ChatWidget from './widgets/ChatWidget';
+import WeatherWidget from './widgets/WeatherWidget';
+import './Dashboard.css';
+
+const defaultLayout = [
+  { i: 'chat', x: 0, y: 0, w: 3, h: 4 },
+  { i: 'weather', x: 3, y: 0, w: 3, h: 2 }
+];
+
+export default function Dashboard() {
+  const [layout, setLayout] = useState(() => {
+    const saved = localStorage.getItem('layout');
+    return saved ? JSON.parse(saved) : defaultLayout;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('layout', JSON.stringify(layout));
+  }, [layout]);
+
+  const handleLayoutChange = (newLayout) => {
+    setLayout(newLayout);
+  };
+
+  return (
+    <GridLayout
+      className="layout"
+      layout={layout}
+      cols={6}
+      rowHeight={30}
+      width={900}
+      onLayoutChange={handleLayoutChange}
+    >
+      <div key="chat">
+        <ChatWidget />
+      </div>
+      <div key="weather">
+        <WeatherWidget />
+      </div>
+    </GridLayout>
+  );
+}

--- a/renderer/react-ui/src/index.css
+++ b/renderer/react-ui/src/index.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #121212;
+}

--- a/renderer/react-ui/src/index.js
+++ b/renderer/react-ui/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import Dashboard from './Dashboard';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<Dashboard />);

--- a/renderer/react-ui/src/widgets/ChatWidget.jsx
+++ b/renderer/react-ui/src/widgets/ChatWidget.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function ChatWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">Chat</div>
+      <div className="widget-body">Chat widget content</div>
+    </div>
+  );
+}

--- a/renderer/react-ui/src/widgets/WeatherWidget.jsx
+++ b/renderer/react-ui/src/widgets/WeatherWidget.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function WeatherWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">Weather</div>
+      <div className="widget-body">Weather widget content</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a React UI dashboard skeleton under `renderer/react-ui`
- configure widgets (chat and weather) with a draggable grid layout
- load the React dashboard during development/production

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c5df32748323bff9a77adbd46c09