### PR TITLE
Add finance and stock widgets

### DIFF
--- a/renderer/react-ui/src/Dashboard.jsx
+++ b/renderer/react-ui/src/Dashboard.jsx
@@ -2,11 +2,21 @@ import React, { useState, useEffect } from 'react';
 import GridLayout from 'react-grid-layout';
 import ChatWidget from './widgets/ChatWidget';
 import WeatherWidget from './widgets/WeatherWidget';
+import StocksWidget from './widgets/StocksWidget';
+import FinanceWidget from './widgets/FinanceWidget';
+import ReminderWidget from './widgets/ReminderWidget';
+import PerformanceWidget from './widgets/PerformanceWidget';
+import VolumeControlWidget from './widgets/VolumeControlWidget';
 import './Dashboard.css';
 
 const defaultLayout = [
   { i: 'chat', x: 0, y: 0, w: 3, h: 4 },
-  { i: 'weather', x: 3, y: 0, w: 3, h: 2 }
+  { i: 'weather', x: 3, y: 0, w: 3, h: 2 },
+  { i: 'stocks', x: 0, y: 6, w: 3, h: 3 },
+  { i: 'finance', x: 3, y: 6, w: 3, h: 3 },
+  { i: 'reminder', x: 6, y: 6, w: 3, h: 3 },
+  { i: 'performance', x: 9, y: 6, w: 3, h: 3 },
+  { i: 'volume', x: 0, y: 9, w: 12, h: 2 }
 ];
 
 export default function Dashboard() {
@@ -27,7 +37,7 @@ export default function Dashboard() {
     <GridLayout
       className="layout"
       layout={layout}
-      cols={6}
+      cols={12}
       rowHeight={30}
       width={900}
       onLayoutChange={handleLayoutChange}
@@ -37,6 +47,21 @@ export default function Dashboard() {
       </div>
       <div key="weather">
         <WeatherWidget />
+      </div>
+      <div key="stocks">
+        <StocksWidget />
+      </div>
+      <div key="finance">
+        <FinanceWidget />
+      </div>
+      <div key="reminder">
+        <ReminderWidget />
+      </div>
+      <div key="performance">
+        <PerformanceWidget />
+      </div>
+      <div key="volume">
+        <VolumeControlWidget />
       </div>
     </GridLayout>
   );

--- a/renderer/react-ui/src/widgets/FinanceWidget.jsx
+++ b/renderer/react-ui/src/widgets/FinanceWidget.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function FinanceWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">Finances</div>
+      <div className="widget-body">
+        {/* TODO: Show finance details */}
+      </div>
+    </div>
+  );
+}

--- a/renderer/react-ui/src/widgets/PerformanceWidget.jsx
+++ b/renderer/react-ui/src/widgets/PerformanceWidget.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function PerformanceWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">System Performance</div>
+      <div className="widget-body">
+        {/* TODO: Show performance metrics */}
+      </div>
+    </div>
+  );
+}

--- a/renderer/react-ui/src/widgets/ReminderWidget.jsx
+++ b/renderer/react-ui/src/widgets/ReminderWidget.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function ReminderWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">Reminders</div>
+      <div className="widget-body">
+        {/* TODO: Add reminder list */}
+      </div>
+    </div>
+  );
+}

--- a/renderer/react-ui/src/widgets/StocksWidget.jsx
+++ b/renderer/react-ui/src/widgets/StocksWidget.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../Dashboard.css';
+
+export default function StocksWidget() {
+  return (
+    <div className="widget">
+      <div className="widget-header">Market Data</div>
+      <div className="widget-body">
+        {/* TODO: Display stock information */}
+      </div>
+    </div>
+  );
+}

--- a/renderer/react-ui/src/widgets/VolumeControlWidget.jsx
+++ b/renderer/react-ui/src/widgets/VolumeControlWidget.jsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import '../Dashboard.css';
+
+export default function VolumeControlWidget() {
+  const [volume, setVolume] = useState(50);
+
+  const handleChange = (e) => {
+    setVolume(e.target.value);
+  };
+
+  return (
+    <div className="widget">
+      <div className="widget-header">Volume</div>
+      <div className="widget-body">
+        <input type="range" min="0" max="100" value={volume} onChange={handleChange} />
+        <div>{volume}</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- update dashboard layout with new widgets
- create five new widgets with placeholders and a sample volume control
- hook new widgets into the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e53022388323ae256d85f926eab7